### PR TITLE
Implement merge with additional translation scan-paths

### DIFF
--- a/config/laradium.php
+++ b/config/laradium.php
@@ -79,5 +79,9 @@ return [
     'component_views' => [
         'user-box-top'    => 'admin._partials.user-box-top',
         'user-box-bottom' => 'admin._partials.user-box-bottom'
+    ],
+
+    'additional_translation_scan_paths' => [
+        //
     ]
 ];

--- a/src/Console/Commands/FindTranslations.php
+++ b/src/Console/Commands/FindTranslations.php
@@ -131,12 +131,13 @@ class FindTranslations extends Command
      */
     protected function getPaths(): array
     {
-        $paths = [
+        $paths = array_merge([
             base_path('app'),
             base_path('modules'),
             base_path('resources'),
             base_path('routes'),
-        ];
+        ], (array)config('laradium.additional_translation_scan_paths', []));
+
         foreach ($paths as $i => $path) {
             if (!File::isDirectory($path)) {
                 unset($paths[$i]);


### PR DESCRIPTION
This merge provides ability to scan translations outside hardcoded directories. Useful when translations are used in helper files outside app root.